### PR TITLE
add home delivery query to comments

### DIFF
--- a/app/csv/Charge.scala
+++ b/app/csv/Charge.scala
@@ -39,7 +39,26 @@ Charge_day // day we're running for
  "","","","","","","","Papers please","","","27/04/2017","28/04/2017","","","","Friday"
  
     */
-   
+   /*
+   SELECT
+      Sold To: Address 1,
+      Sold To: Address 2,
+      Sold To: City,
+      Sold To: Country,
+      Sold To: First Name,
+      Sold To: Last Name,
+      Sold To: Postal Code,
+      Sold To: State/Province,
+      Subscription: Name
+   FROM rateplancharge
+   WHERE
+      (((((((((Subscription.Status != 'Draft' and Subscription.Status != 'Pending Activation') and Subscription.Status != 'Expired') and Subscription.Status != 'Suspended') and Subscription.Status != 'Pending Acceptance')
+       and Account.Balance >= 0)
+        and ProductRatePlanCharge.ProductType__c = 'Print Saturday')
+         and Product.Name = 'Newspaper Delivery')
+          and RatePlanCharge.EffectiveStartDate <= '27/04/2017')
+           and RatePlanCharge.EffectiveEndDate >= '27/04/2017')
+    */
    
   val Rate_Plan_Charge__Charged_Through_Date = 0
   val Rate_Plan_Charge__DMRC = 1


### PR DESCRIPTION
Here is the query I think we need for home delivery, it needs converting to an actual query for the api rather than using display names but it's basically right.

once @satterly has the code to hit the api directly we can wire it in and correct all the field names.  In the mean time I'll make something to parse up the CSV and write it out in the new format.

cc @pvighi @lmath 